### PR TITLE
Simplify prereqs/deploys, extend frontend readiness probe

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -54,26 +54,12 @@ jobs:
       img_fallback: test
       triggers: ${{ matrix.triggers }}
 
-  tests:
-    name: Unit Tests
-    needs:
-      - builds
-    # If any of the prerequs created a build, then run tests
-    if: contains(needs.*.outputs.build, 'true')
-    uses: bcgov/nr-quickstart-helpers/.github/workflows/_unit-tests.yml@v0.0.2
-    strategy:
-      matrix:
-        component: [backend, frontend]
-    with:
-      component: ${{ matrix.component }}
-      test_cmd: npm run test
-
   deploys:
     name: Deploys
     needs:
       - builds
-    # If any of the prerequs created a build, then deploy
-    if: contains(needs.*.outputs.build, 'true')
+    # # If any of the prerequs created a build, then deploy
+    # if: contains(needs.*.outputs.build, 'true')
     uses: bcgov/nr-quickstart-helpers/.github/workflows/_deploy.yml@v0.0.2
     strategy:
       matrix:
@@ -102,10 +88,19 @@ jobs:
       template_file: ${{ matrix.template_file }}
       template_vars: ${{ matrix.template_vars }}
 
+  tests:
+    name: Unit Tests
+    uses: bcgov/nr-quickstart-helpers/.github/workflows/_unit-tests.yml@v0.0.2
+    strategy:
+      matrix:
+        component: [backend, frontend]
+    with:
+      component: ${{ matrix.component }}
+      test_cmd: npm run test
+
   sonarcloud:
     name: Static Analysis
     needs:
-      - deploys
       - tests
     runs-on: ubuntu-22.04
     steps:

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -102,7 +102,7 @@ objects:
                   path: /
                   port: 3000
                   scheme: HTTP
-                initialDelaySeconds: 15
+                initialDelaySeconds: 30
                 periodSeconds: 30
                 timeoutSeconds: 5
   - apiVersion: v1


### PR DESCRIPTION
Simplify the pipeline while undergoing heavy revision.

Extend Frontend's readiness probe, since it's been semi-regularly failing verification.
<p>

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-quickstart-helpers-539-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-quickstart-helpers-539-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-quickstart-typescript/actions/workflows/merge-main.yml)