### PR TITLE
Testing and restore frontend liveness probe periodseconds=15

### DIFF
--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -102,7 +102,7 @@ objects:
                   path: /
                   port: 3000
                   scheme: HTTP
-                initialDelaySeconds: 30
+                initialDelaySeconds: 15
                 periodSeconds: 30
                 timeoutSeconds: 5
   - apiVersion: v1


### PR DESCRIPTION
Earlier change to probe wasn't useful.  Deployment Verification (_deploy helper) was frequently false failing.  Retries have been added in the Helpers repo, so this PR is testing that and undoing the previous probe change.
<p>

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-quickstart-helpers-540-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-quickstart-helpers-540-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-quickstart-typescript/actions/workflows/merge-main.yml)