### PR TITLE
Set token permissions for builds, failing for fork PRs

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -38,6 +38,8 @@ jobs:
   builds:
     name: Builds
     uses: bcgov/nr-quickstart-helpers/.github/workflows/_build.yml@v0.0.2
+    permissions:
+      packages: write
     strategy:
       matrix:
         component: [backend, frontend]


### PR DESCRIPTION
PRs kicked off by forks are failing on package creation. This is very likely permission related.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-quickstart-helpers-555-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-quickstart-helpers-555-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-quickstart-typescript/actions/workflows/merge-main.yml)