### PR TITLE
SonarCloud badge, PR reordering and more standard token

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -71,7 +71,7 @@ jobs:
             -Dsonar.javascript.lcov.reportPaths=backend/coverage/lcov.info,frontend/coverage/lcov.info
             -Dsonar.cobertura.reportPaths=backend/coverage/cobertura-coverage.xml,frontend/coverage/cobertura-coverage.xml
             -Dsonar.project.monorepo.enabled=true
-            -Dsonar.projectKey=${{ github.event.repository.name }}
+            -Dsonar.projectKey=bcgov_${{ github.event.repository.name }}
             -Dsonar.sources=backend,frontend
             -Dsonar.tests=backend/test,frontend/test
 

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -144,7 +144,7 @@ jobs:
             -Dsonar.javascript.lcov.reportPaths=backend/coverage/lcov.info,frontend/coverage/lcov.info
             -Dsonar.cobertura.reportPaths=backend/coverage/cobertura-coverage.xml,frontend/coverage/cobertura-coverage.xml
             -Dsonar.project.monorepo.enabled=true
-            -Dsonar.projectKey=${{ github.event.repository.name }}
+            -Dsonar.projectKey=bcgov_${{ github.event.repository.name }}
             -Dsonar.sources=backend,frontend
             -Dsonar.tests=backend/test,frontend/test
 

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -107,6 +107,7 @@ jobs:
   sonarcloud:
     name: Static Analysis
     needs:
+      - deploys
       - tests
     runs-on: ubuntu-22.04
     steps:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![Issues](https://img.shields.io/github/issues/bcgov/nr-quickstart-typescript)](/../../issues)
 [![MIT License](https://img.shields.io/github/license/bcgov/nr-quickstart-typescript.svg)](/LICENSE.md)
 [![Lifecycle](https://img.shields.io/badge/Lifecycle-Experimental-339999)](https://github.com/bcgov/repomountie/blob/master/doc/lifecycle-badges.md)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=bcgov_nr-quickstart-typescript&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=bcgov_nr-quickstart-typescript)
+
 
 # Natural Resources QuickStart
 


### PR DESCRIPTION
Changes:
- Added SonarCloud badge to README.md
- Make SonarCloud the last step in PRs to reduce email notifications
- Prefixed sonar token with `bcgov_`, since this is standard for BCGov repos