### PR TITLE
Stop SonarCloud comments, but still stop workflow on fail

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -102,12 +102,11 @@ jobs:
         component: [backend, frontend]
     with:
       component: ${{ matrix.component }}
-      test_cmd: npm run test
+      test_cmd: npm run test:cov
 
   sonarcloud:
     name: Static Analysis
     needs:
-      - deploys
       - tests
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
SonarCloud comments are still adding up.  Using SC as a final step also wasn't working for merge requirements.  This PR makes only unit tests a prerequisite for SonarCloud and stops PR commenting.  Merge requirements are changed to require a successful reporting of SC, not of the kick-off job itself.

Changes were made to branch protection that do not show in this pull request.  The settings are available here:
`Settings > Branches > main: edit > Require status checks to pass before merging.`

SonarCloud will continue to fail the pipeline if a problem is found.