### PR TITLE
SonarCloud monorepo mode (2x projects)

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -37,49 +37,91 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
 
-  # SonarCloud runs in the main branch are needed to compare against PRs
-  sonarcloud:
-    name: Static Analysis
+  tests:
+    name: Unit Tests
+    uses: bcgov/nr-quickstart-helpers/.github/workflows/_unit-tests.yml@v0.0.2
+    strategy:
+      matrix:
+        component: [backend, frontend]
+    with:
+      component: ${{ matrix.component }}
+      test_cmd: npm run test:cov
+
+  sonarcloud-backend:
+    name: Static Analysis Backend
+    needs:
+      - tests
     runs-on: ubuntu-22.04
     steps:
+      # Disable shallow clone for SonarCloud analysis
       - uses: actions/checkout@v3
-        # Disable shallow clone for SonarCloud analysis
         with:
           fetch-depth: 0
 
-      - name: Backend Tests
-        run: |
-          cd frontend
-          npm ci
-          npm run test:cov
+      - name: Get Backend coverage from cache
+        uses: actions/cache@v3
+        with:
+          path: backend/coverage
+          key: coverage-backend-${{ github.run_number }}
+          restore-keys: |
+            coverage-backend-
 
-      - name: Frontend Tests
-        run: |
-          cd frontend
-          npm ci
-          npm run test:cov
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          # Needed to get PR information, if any
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_BACKEND }}
+        with:
+          projectBaseDir: backend
+          args: >
+            -Dsonar.cobertura.reportPaths=coverage/cobertura-coverage.xml
+            -Dsonar.exclusions=**/test/**,.github/**/*,*.md
+            -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
+            -Dsonar.organization=bcgov-sonarcloud
+            -Dsonar.project.monorepo.enabled=true
+            -Dsonar.projectKey=bcgov_nr-quickstart-typescript_backend
+            -Dsonar.tests=test
+
+  sonarcloud-frontend:
+    name: SonarCloud Frontend
+    needs:
+      - tests
+    runs-on: ubuntu-latest
+    steps:
+      # Disable shallow clone for SonarCloud analysis
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get Backend coverage from cache
+        uses: actions/cache@v3
+        with:
+          path: backend/coverage
+          key: coverage-backend-${{ github.run_number }}
+          restore-keys: |
+            coverage-backend-
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_FRONTEND }}
         with:
+          projectBaseDir: frontend
           args: >
-            -Dsonar.exclusions=**/test/**,.github/**/*
+            -Dsonar.cobertura.reportPaths=coverage/cobertura-coverage.xml
+            -Dsonar.exclusions=**/test/**,.github/**/*,*.md
+            -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
             -Dsonar.organization=bcgov-sonarcloud
-            -Dsonar.javascript.lcov.reportPaths=backend/coverage/lcov.info,frontend/coverage/lcov.info
-            -Dsonar.cobertura.reportPaths=backend/coverage/cobertura-coverage.xml,frontend/coverage/cobertura-coverage.xml
             -Dsonar.project.monorepo.enabled=true
-            -Dsonar.projectKey=bcgov_${{ github.event.repository.name }}
-            -Dsonar.sources=backend,frontend
-            -Dsonar.tests=backend/test,frontend/test
+            -Dsonar.projectKey=bcgov_nr-quickstart-typescript_frontend
+            -Dsonar.tests=test
 
   deploys-test:
     name: TEST Deployments
     needs:
       - codeql
-      - sonarcloud
     uses: bcgov/nr-quickstart-helpers/.github/workflows/_deploy.yml@v0.0.2
     strategy:
       matrix:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -104,8 +104,8 @@ jobs:
       component: ${{ matrix.component }}
       test_cmd: npm run test:cov
 
-  sonarcloud:
-    name: Static Analysis
+  sonarcloud-backend:
+    name: Static Analysis Backend
     needs:
       - tests
     runs-on: ubuntu-22.04
@@ -115,7 +115,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get backend coverage from cache
+      - name: Get Backend coverage from cache
         uses: actions/cache@v3
         with:
           path: backend/coverage
@@ -123,30 +123,59 @@ jobs:
           restore-keys: |
             coverage-backend-
 
-      - name: Get frontend coverage from cache
-        uses: actions/cache@v3
-        with:
-          path: frontend/coverage
-          key: coverage-frontend-${{ github.run_number }}
-          restore-keys: |
-            coverage-frontend-
-
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         env:
           # Needed to get PR information, if any
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_BACKEND }}
         with:
+          projectBaseDir: backend
           args: >
+            -Dsonar.cobertura.reportPaths=coverage/cobertura-coverage.xml
             -Dsonar.exclusions=**/test/**,.github/**/*,*.md
+            -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
             -Dsonar.organization=bcgov-sonarcloud
-            -Dsonar.javascript.lcov.reportPaths=backend/coverage/lcov.info,frontend/coverage/lcov.info
-            -Dsonar.cobertura.reportPaths=backend/coverage/cobertura-coverage.xml,frontend/coverage/cobertura-coverage.xml
             -Dsonar.project.monorepo.enabled=true
-            -Dsonar.projectKey=bcgov_${{ github.event.repository.name }}
-            -Dsonar.sources=backend,frontend
-            -Dsonar.tests=backend/test,frontend/test
+            -Dsonar.projectKey=bcgov_nr-quickstart-typescript_backend
+            -Dsonar.projectName=backend
+            -Dsonar.tests=test
+
+  sonarcloud-frontend:
+    name: SonarCloud Frontend
+    needs:
+      - tests
+    runs-on: ubuntu-latest
+    steps:
+      # Disable shallow clone for SonarCloud analysis
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get Backend coverage from cache
+        uses: actions/cache@v3
+        with:
+          path: backend/coverage
+          key: coverage-backend-${{ github.run_number }}
+          restore-keys: |
+            coverage-backend-
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_FRONTEND }}
+        with:
+          projectBaseDir: frontend
+          args: >
+            -Dsonar.cobertura.reportPaths=coverage/cobertura-coverage.xml
+            -Dsonar.exclusions=**/test/**,.github/**/*,*.md
+            -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
+            -Dsonar.organization=bcgov-sonarcloud
+            -Dsonar.project.monorepo.enabled=true
+            -Dsonar.projectKey=bcgov_nr-quickstart-typescript_frontend
+            -Dsonar.projectName=backend
+            -Dsonar.tests=test
 
   # # Uncomment to view GitHub context object
   # # https://docs.github.com/en/actions/learn-github-actions/contexts

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -138,7 +138,6 @@ jobs:
             -Dsonar.organization=bcgov-sonarcloud
             -Dsonar.project.monorepo.enabled=true
             -Dsonar.projectKey=bcgov_nr-quickstart-typescript_backend
-            -Dsonar.projectName=backend
             -Dsonar.tests=test
 
   sonarcloud-frontend:
@@ -174,7 +173,6 @@ jobs:
             -Dsonar.organization=bcgov-sonarcloud
             -Dsonar.project.monorepo.enabled=true
             -Dsonar.projectKey=bcgov_nr-quickstart-typescript_frontend
-            -Dsonar.projectName=backend
             -Dsonar.tests=test
 
   # # Uncomment to view GitHub context object


### PR DESCRIPTION
Try setting up SonarCloud in monorepo mode.  Uses two projects set up as monorepos.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-quickstart-typescript-580-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-quickstart-typescript-580-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-quickstart-typescript/actions/workflows/merge-main.yml)