### PR TITLE
SonarCloud in _unit-tests helper

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -18,8 +18,8 @@ jobs:
       pull-requests: write
     steps:
       - name: PR Greeting
-        # Run if PR opened or reopened
-        if: contains(github.event.action, 'opened')
+        # # Run if PR opened or reopened
+        # if: contains(github.event.action, 'opened')
         uses: DerekRoberts/action-pr-description-add@v0.0.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -95,14 +95,28 @@ jobs:
       template_vars: ${{ matrix.template_vars }}
 
   tests:
-    name: Unit Tests
-    uses: bcgov/nr-quickstart-helpers/.github/workflows/_unit-tests.yml@v0.0.2
+    name: Unit Tests and Analysis
+    uses: bcgov/nr-quickstart-helpers/.github/workflows/_unit-tests.yml@v0.0.3
     strategy:
       matrix:
-        component: [backend, frontend]
+        dir: [backend, frontend]
+        include:
+          - dir: backend
+            sonar_projectKey: bcgov_nr-quickstart-typescript_backend
+            sonar_token: SONAR_TOKEN_BACKEND
+          - dir: frontend
+            sonar_projectKey: bcgov_nr-quickstart-typescript_frontend
+            sonar_token: SONAR_TOKEN_FRONTEND
+    secrets:
+      sonar_token: ${{ secrets[matrix.sonar_token] }}
     with:
-      component: ${{ matrix.component }}
-      test_cmd: npm run test:cov
+      dir: ${{ matrix.dir }}
+      sonar_args: >
+        -Dsonar.organization=bcgov-sonarcloud
+        -Dsonar.projectKey=${{ matrix.sonar_projectKey }}
+      test_cmd: |
+        npm ci
+        npm run test:cov
 
   sonarcloud:
     name: SonarCloud

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -96,7 +96,7 @@ jobs:
 
   tests:
     name: Unit Tests and Analysis
-    uses: bcgov/nr-quickstart-helpers/.github/workflows/_unit-tests.yml@v0.0.3
+    uses: bcgov/nr-quickstart-helpers/.github/workflows/_unit-tests.yml@main
     strategy:
       matrix:
         dir: [backend, frontend]


### PR DESCRIPTION
Run SonarCloud in _unit-tests helper.  Tested using a temporary feature branch.  It can't be merged until that option is released in nr-quickstart-helpers@v0.0.3.

Update: Temporarily using main instead of a version number to merge.  Will fix.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-quickstart-typescript-582-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-quickstart-typescript-582-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-quickstart-typescript/actions/workflows/merge-main.yml)

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-quickstart-typescript-582-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-quickstart-typescript-582-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-quickstart-typescript/actions/workflows/merge-main.yml)