### PR TITLE
Update bcgov-nr/action-deployer-openshift to v0.0.2

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -83,7 +83,7 @@ jobs:
             file: common/openshift.init.yml
             overwrite: false
     steps:
-      - uses: bcgov-nr/action-deployer-openshift@v0.0.1
+      - uses: bcgov-nr/action-deployer-openshift@v0.0.2
         with:
           file: ${{ matrix.file }}
           oc_namespace: ${{ secrets.OC_NAMESPACE }}
@@ -118,7 +118,7 @@ jobs:
             file: common/openshift.init.yml
             overwrite: false
     steps:
-      - uses: bcgov-nr/action-deployer-openshift@v0.0.1
+      - uses: bcgov-nr/action-deployer-openshift@v0.0.2
         with:
           file: ${{ matrix.file }}
           oc_namespace: ${{ secrets.OC_NAMESPACE }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -92,7 +92,7 @@ jobs:
             file: common/openshift.init.yml
             overwrite: false
     steps:
-      - uses: bcgov-nr/action-deployer-openshift@v0.0.1
+      - uses: bcgov-nr/action-deployer-openshift@v0.0.2
         with:
           file: ${{ matrix.file }}
           oc_namespace: ${{ secrets.OC_NAMESPACE }}


### PR DESCRIPTION


---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-quickstart-typescript-624-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-quickstart-typescript-624-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-quickstart-typescript/actions/workflows/merge-main.yml)