### PR TITLE
Skip Unit Tests when PR=draft

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,11 +2,15 @@ name: Unit Tests and Analysis
 
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   push:
     branches:
       - main
     paths-ignore:
-      - ".github/**"
       - "**.md"
   workflow_dispatch:
 
@@ -17,6 +21,7 @@ concurrency:
 jobs:
   tests:
     name: Unit Tests
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-22.04
     strategy:
       matrix:


### PR DESCRIPTION
Skip unit tests and associated noise/costs until a PR is taken out of draft.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-quickstart-typescript-633-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-quickstart-typescript-633-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-quickstart-typescript/actions/workflows/merge-main.yml)