### PR TITLE
Switch to auto/default CodeQL runs

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -14,33 +14,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  codeql:
-    name: Semantic Code Analysis
+  wait:
+    name: Wait
     runs-on: ubuntu-22.04
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Initialize
-        uses: github/codeql-action/init@v2
-        with:
-          languages: javascript
-
-      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-      # If this step fails, then you should remove it and run the build manually (see below)
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+      - run: |
+          # Sleep 30 - let PR images promote
+          sleep 30
 
   deploys-test:
     name: TEST Deployments
     needs:
-      - codeql
+      - wait
     environment: test
     runs-on: ubuntu-22.04
     strategy:


### PR DESCRIPTION
GitHub Actions can now run CodeQL without needing a custom job in our workflows.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-quickstart-typescript-799-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-quickstart-typescript-799-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-quickstart-typescript/actions/workflows/merge-main.yml)