### PR TITLE
Use Renovate instead of Dependabot for npm udpates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,18 +7,18 @@ updates:
     schedule:
       interval: daily
 
-  - package-ecosystem: npm
-    directory: /backend
-    schedule:
-      interval: daily
-    commit-message:
-      prefix: "Backend"
-      include: "scope"
+  # - package-ecosystem: npm
+  #   directory: /backend
+  #   schedule:
+  #     interval: daily
+  #   commit-message:
+  #     prefix: "Backend"
+  #     include: "scope"
 
-  - package-ecosystem: npm
-    directory: /frontend
-    schedule:
-      interval: daily
-    commit-message:
-      prefix: "Frontend"
-      include: "scope"
+  # - package-ecosystem: npm
+  #   directory: /frontend
+  #   schedule:
+  #     interval: daily
+  #   commit-message:
+  #     prefix: "Frontend"
+  #     include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,19 +6,3 @@ updates:
     directory: /
     schedule:
       interval: daily
-
-  # - package-ecosystem: npm
-  #   directory: /backend
-  #   schedule:
-  #     interval: daily
-  #   commit-message:
-  #     prefix: "Backend"
-  #     include: "scope"
-
-  # - package-ecosystem: npm
-  #   directory: /frontend
-  #   schedule:
-  #     interval: daily
-  #   commit-message:
-  #     prefix: "Frontend"
-  #     include: "scope"


### PR DESCRIPTION
Renovate is in place and more or less running even with Dependabot.  Comment out npm packages from .github/dependabot.yml, leaving Dependabot only running GitHub Actions updates.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-quickstart-typescript-878-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-quickstart-typescript-878-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-quickstart-typescript/actions/workflows/merge-main.yml)