### PR TITLE
Simplify, disable dependency dashboard

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -1,7 +1,8 @@
 name: Pull Request
 
 on:
-  pull_request:
+  workflow_dispatch:
+  # pull_request:
 
 concurrency:
   # PR open and close use the same group, allowing only one at a time

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -1,8 +1,7 @@
 name: Pull Request
 
 on:
-  workflow_dispatch:
-  # pull_request:
+  pull_request:
 
 concurrency:
   # PR open and close use the same group, allowing only one at a time

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,15 +1,16 @@
 name: Renovate
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - ".github/ISSUE_TEMPLATE/*"
-      - "**.md"
-  schedule:
-    # Quotes required for "*" (#42, asterisk), special semantics in YAML
-    - cron: "0 11 * * *" # 3 AM PST = 11 AM UDT
-  workflow_dispatch:
+  pull_request:
+  # push:
+  #   branches:
+  #     - main
+  #   paths-ignore:
+  #     - ".github/ISSUE_TEMPLATE/*"
+  #     - "**.md"
+  # schedule:
+  #   # Quotes required for "*" (#42, asterisk), special semantics in YAML
+  #   - cron: "0 11 * * *" # 3 AM PST = 11 AM UDT
+  # workflow_dispatch:
 
 jobs:
   renovate:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,16 +1,16 @@
 name: Renovate
 on:
   pull_request:
-  # push:
-  #   branches:
-  #     - main
-  #   paths-ignore:
-  #     - ".github/ISSUE_TEMPLATE/*"
-  #     - "**.md"
-  # schedule:
-  #   # Quotes required for "*" (#42, asterisk), special semantics in YAML
-  #   - cron: "0 11 * * *" # 3 AM PST = 11 AM UDT
-  # workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - ".github/ISSUE_TEMPLATE/*"
+      - "**.md"
+  schedule:
+    # Quotes required for "*" (#42, asterisk), special semantics in YAML
+    - cron: "0 11 * * *" # 3 AM PST = 11 AM UDT
+  workflow_dispatch:
 
 jobs:
   renovate:

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,11 @@
 {
   "extends": [
     "config:base",
-    ":disableDependencyDashboard"
+    ":app",
+    ":library"
   ],
   "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
+  "dependencyDashboard": false,
   "repositories": [
     "bcgov/nr-quickstart-typescript"
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -1,16 +1,17 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":disableDependencyDashboard"
   ],
-  "autodiscover": true,
-  "autodiscoverFilter": "bcgov/nr-quickstart-typescript",
   "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
+  "repositories": [
+    "bcgov/nr-quickstart-typescript"
+  ],
   "configMigration": true,
   "configWarningReuseIssue": true,
-  "onboarding": false,
   "packageRules": [
     {
-      "dependencyDashboardApproval": true,
+      "dependencyDashboardApproval": false,
       "matchManagers": [
         "npm"
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
   "repositories": [
     "bcgov/nr-quickstart-typescript"
   ],
+  "rebaseWhen": "behind-base-branch",
   "dryRun": "full",
   "configMigration": true,
   "configWarningReuseIssue": true,
@@ -53,5 +54,8 @@
     }
   ],
   "platform": "github",
-  "username": "renovate-release"
+  "username": "renovate-release",
+  "vulnerabilityAlerts": {
+    "enabled": true
+  }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,61 +1,55 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Default preset for use with Renovate's repos",
   "extends": [
     "config:base",
-    ":app",
-    ":library"
+    ":maintainLockFilesWeekly",
+    ":rebaseStalePrs",
+    ":semanticCommits",
+    ":semanticCommitScope(deps)",
+    "docker:enableMajor",
+    "docker:pinDigests",
+    "group:linters"
   ],
+  "username": "renovate-release",
   "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
-  "dependencyDashboard": false,
-  "repositories": [
-    "bcgov/nr-quickstart-typescript"
-  ],
-  "rebaseWhen": "behind-base-branch",
+  "onboarding": true,
+  "platform": "github",
+  "includeForks": false,
   "dryRun": "full",
   "configMigration": true,
-  "configWarningReuseIssue": true,
+  "dependencyDashboard": true,
+  "prCreation": "not-pending",
+  "rebaseWhen": "behind-base-branch",
+  "repositories": [
+    "bcgov/nr-quickstart-typescript",
+    "bcgov/nr-forest-client"
+  ],
   "packageRules": [
     {
-      "matchManagers": [
+      "description": "Require dashboard approval for major updates",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Group prettier packages",
+      "matchPackageNames": [
+        "prettier"
+      ],
+      "matchPackagePatterns": [
+        "^@prettier\\/",
+        "^prettier-plugin-"
+      ],
+      "groupName": "prettier packages"
+    },
+    {
+      "description": "One week stability period for npm packages",
+      "matchDatasources": [
         "npm"
       ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch",
-        "lockFileMaintenance"
-      ],
-      "addLabels": [
-        "dependencies",
-        "javascript"
-      ],
-      "prConcurrentLimit": 5,
-      "groupName": "npm all non-major dependencies",
-      "groupSlug": "npm all-minor-patch"
-    },
-    {
-      "matchManagers": [
-        "github-actions"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "addLabels": [
-        "dependencies"
-      ],
-      "groupName": "github actions all non-major dependencies",
-      "groupSlug": "github actions all-minor-patch"
-    },
-    {
-      "matchManagers": [
-        "dockerfile",
-        "docker-compose"
-      ],
-      "enabled": false
+      "stabilityDays": 7
     }
-  ],
-  "platform": "github",
-  "username": "renovate-release",
-  "vulnerabilityAlerts": {
-    "enabled": true
-  }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -27,6 +27,29 @@
   ],
   "packageRules": [
     {
+      "matchManagers": [
+        "npm"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "lockFileMaintenance"
+      ],
+      "groupName": "npm all non-major dependencies",
+      "groupSlug": "npm all-minor-patch"
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "github actions all non-major dependencies",
+      "groupSlug": "github actions all-minor-patch"
+    },
+    {
       "description": "Require dashboard approval for major updates",
       "matchUpdateTypes": [
         "major"

--- a/renovate.json
+++ b/renovate.json
@@ -7,11 +7,11 @@
   "repositories": [
     "bcgov/nr-quickstart-typescript"
   ],
+  "dryRun": "full",
   "configMigration": true,
   "configWarningReuseIssue": true,
   "packageRules": [
     {
-      "dependencyDashboardApproval": false,
       "matchManagers": [
         "npm"
       ],


### PR DESCRIPTION
Renovate is creating many dependency dashboard issues and other noise.  This attempts to combine PRs and stop the issues.

Update: Renovate is getting moved out of this repo soon.