### PR TITLE
Set permissions.package:write for retag action

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -112,6 +112,8 @@ jobs:
     needs:
       - deploys-prod
     runs-on: ubuntu-22.04
+    permissions:
+      packages: write
     strategy:
       matrix:
         component: [backend, database, frontend]

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -29,6 +29,8 @@ jobs:
     name: Image Promotions
     if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-22.04
+    permissions:
+      packages: write
     strategy:
       matrix:
         package: [backend, database, frontend]


### PR DESCRIPTION
Addresses a bug that came up after moving one of the templated repos between orgs.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-quickstart-typescript-1020-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-quickstart-typescript-1020-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-quickstart-typescript/actions/workflows/merge-main.yml)