### PR TITLE
ci: updating concurrency on pr open and close

### DIFF
--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   # PR open and close use the same group, allowing only one at a time
-  group: pr-${{ github.ref }}
+  group: pr-${{ github.workflow }}-${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -5,7 +5,7 @@ on:
 
 concurrency:
   # PR open and close use the same group, allowing only one at a time
-  group: pr-${{ github.ref }}
+  group: pr-${{ github.workflow }}-${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
this will allow multiple workflows to run in parallel without conflicting.

previously you could clash two different workflows, like close in case they ran at the same time

## Type of change



---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-quickstart-typescript-1042-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-quickstart-typescript-1042-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-quickstart-typescript/actions/workflows/merge-main.yml)