### PR TITLE
Trivy param security-checks -> scanners

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -60,7 +60,7 @@ jobs:
           output: "trivy-results.sarif"
           ignore-unfixed: true
           scan-type: "fs"
-          security-checks: "vuln,secret,config"
+          scanners: "vuln,secret,config"
           severity: "CRITICAL,HIGH"
 
       - name: Upload Trivy scan results to GitHub Security tab


### PR DESCRIPTION
Trivy's Action renamed the `security-checks` parameter to `scanners`.