### PR TITLE
chore(deps): update caddy docker tag to v2.6.4

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -9,30 +9,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pr-greeting:
-    name: PR Greeting
-    env:
-      DOMAIN: apps.silver.devops.gov.bc.ca
-      PREFIX: ${{ github.event.repository.name }}-${{ github.event.number }}
-    runs-on: ubuntu-22.04
-    permissions:
-      pull-requests: write
-    steps:
-      - name: PR Greeting
-        uses: bcgov-nr/action-pr-description-add@v0.0.2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          add_markdown: |
-            ---
+  # pr-greeting:
+  #   name: PR Greeting
+  #   env:
+  #     DOMAIN: apps.silver.devops.gov.bc.ca
+  #     PREFIX: ${{ github.event.repository.name }}-${{ github.event.number }}
+  #   runs-on: ubuntu-22.04
+  #   permissions:
+  #     pull-requests: write
+  #   steps:
+  #     - name: PR Greeting
+  #       uses: bcgov-nr/action-pr-description-add@v0.0.2
+  #       with:
+  #         github_token: ${{ secrets.GITHUB_TOKEN }}
+  #         add_markdown: |
+  #           ---
 
-            Thanks for the PR!
+  #           Thanks for the PR!
 
-            Any successful deployments (not always required) will be available below.
-            [Backend](https://${{ env.PREFIX }}-backend.${{ env.DOMAIN }}/) available
-            [Frontend](https://${{ env.PREFIX }}-frontend.${{ env.DOMAIN }}/) available
+  #           Any successful deployments (not always required) will be available below.
+  #           [Backend](https://${{ env.PREFIX }}-backend.${{ env.DOMAIN }}/) available
+  #           [Frontend](https://${{ env.PREFIX }}-frontend.${{ env.DOMAIN }}/) available
 
-            Once merged, code will be promoted and handed off to following workflow run.
-            [Main Merge Workflow](https://github.com/${{ github.repository }}/actions/workflows/merge-main.yml)
+  #           Once merged, code will be promoted and handed off to following workflow run.
+  #           [Main Merge Workflow](https://github.com/${{ github.repository }}/actions/workflows/merge-main.yml)
 
   builds:
     name: Builds
@@ -41,12 +41,12 @@ jobs:
       packages: write
     strategy:
       matrix:
-        package: [backend, database, frontend]
+        # package: [backend, database, frontend]
         include:
-          - package: backend
-            triggers: ('backend/')
-          - package: database
-            triggers: ('database/')
+          # - package: backend
+          #   triggers: ('backend/')
+          # - package: database
+          #   triggers: ('database/')
           - package: frontend
             triggers: ('frontend/')
     steps:
@@ -66,22 +66,22 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        name: [backend, database, init, frontend]
+        # name: [backend, database, init, frontend]
         include:
-          - name: backend
-            file: backend/openshift.deploy.yml
-            overwrite: true
-            parameters: -p MIN_REPLICAS=1 -p MAX_REPLICAS=2
-          - name: database
-            file: database/openshift.deploy.yml
-            overwrite: false
+          # - name: backend
+          #   file: backend/openshift.deploy.yml
+          #   overwrite: true
+          #   parameters: -p MIN_REPLICAS=1 -p MAX_REPLICAS=2
+          # - name: database
+          #   file: database/openshift.deploy.yml
+          #   overwrite: false
           - name: frontend
             file: frontend/openshift.deploy.yml
             overwrite: true
             parameters: -p MIN_REPLICAS=1 -p MAX_REPLICAS=2
-          - name: init
-            file: common/openshift.init.yml
-            overwrite: false
+          # - name: init
+          #   file: common/openshift.init.yml
+          #   overwrite: false
     steps:
       - uses: bcgov-nr/action-deployer-openshift@v1.0.3
         with:

--- a/frontend-react/Dockerfile
+++ b/frontend-react/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 RUN yarn install --frozen-lockfile
 RUN yarn build
 
-FROM caddy:2.4.6-alpine AS deploy
+FROM caddy:2.6.4-alpine AS deploy
 COPY --from=build /app/Caddyfile /etc/caddy/Caddyfile
 COPY --from=build /app/build /srv
 

--- a/frontend-react/Dockerfile
+++ b/frontend-react/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:19-bullseye@sha256:1fab548e95c779df229e4b50d8d20e222597bda15aeece508098c5ba7723302e AS build
+FROM node:19-bullseye AS build
 
 WORKDIR /app
 COPY . .
 RUN yarn install --frozen-lockfile
 RUN yarn build
 
-FROM caddy:2.4.6-alpine@sha256:15e576e7d00b1f41a648c5295a03677c24da5fede09131edcb1e6d809c7dc8aa AS deploy
+FROM caddy:2.4.6-alpine AS deploy
 COPY --from=build /app/Caddyfile /etc/caddy/Caddyfile
 COPY --from=build /app/build /srv
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -15,8 +15,10 @@ FROM caddy:2.6.4-alpine
 ARG PORT
 
 # Copy Caddyfile and static files
-COPY --from=build /app/Caddyfile /etc/caddy/Caddyfile
-COPY --from=build /app/dist /srv
+# COPY --from=build /app/Caddyfile /etc/caddy/Caddyfile
+# COPY --from=build /app/dist /srv
+COPY --from=build /app/dist /usr/share/caddy
+RUN ls /usr/share/caddy
 
 # Port, Healthcheck and user
 EXPOSE ${PORT}

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,13 +1,13 @@
 ### Global args
 ARG PORT 3000
-ARG SRC
+ARG SRC /app
 
 ### Builder
 FROM node:alpine3.16 AS build
 ARG SRC
 
 # Build static files
-WORKDIR /${SRC}
+WORKDIR ${SRC}
 COPY . .
 RUN npm ci && \
     npm run build
@@ -18,8 +18,8 @@ ARG PORT
 ARG SRC
 
 # Copy Caddyfile and static files
-COPY --from=build /${SRC}/Caddyfile /etc/caddy/Caddyfile
-COPY --from=build /${SRC}/dist /srv
+COPY --from=build ${SRC}/Caddyfile /etc/caddy/Caddyfile
+COPY --from=build ${SRC}/dist /srv
 
 # Port, Healthcheck and user
 EXPOSE ${PORT}

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,11 +1,13 @@
 ### Global args
 ARG PORT 3000
+ARG SRC
 
 ### Builder
 FROM node:alpine3.16 AS build
+ARG SRC
 
 # Build static files
-WORKDIR /app
+WORKDIR /${SRC}
 COPY . .
 RUN npm ci && \
     npm run build
@@ -13,16 +15,13 @@ RUN npm ci && \
 ### Deploy
 FROM caddy:2.6.4-alpine
 ARG PORT
+ARG SRC
 
 # Copy Caddyfile and static files
-# COPY --from=build /app/Caddyfile /etc/caddy/Caddyfile
-# COPY --from=build /app/dist /srv
-COPY --from=build /app/dist /usr/share/caddy
-RUN ls /usr/share/caddy
+COPY --from=build /${SRC}/Caddyfile /etc/caddy/Caddyfile
+COPY --from=build /${SRC}/dist /srv
 
 # Port, Healthcheck and user
 EXPOSE ${PORT}
 HEALTHCHECK --interval=30s --timeout=3s \
     CMD curl -f http://localhost/:${PORT} || exit 1
-# USER app
-RUN cat /etc/passwd

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,7 +2,7 @@
 ARG PORT 3000
 
 ### Builder
-FROM node:alpine3.16@sha256:dda50fd533b57096bfb959afa8bfd290dc3c127207907177b578d44ee14d7119 AS build
+FROM node:alpine3.16 AS build
 
 # Build static files
 WORKDIR /app
@@ -10,20 +10,11 @@ COPY . .
 RUN npm ci && \
     npm run build
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 ### Deploy
-FROM caddy:2.4.6-alpine@sha256:15e576e7d00b1f41a648c5295a03677c24da5fede09131edcb1e6d809c7dc8aa
+FROM caddy:2.6.4-alpine
 ARG PORT
 
 # Copy Caddyfile and static files
-=======
-FROM caddy:2.6.4-alpine@sha256:aacae65cfdcf61777306cf7c131fb968f67bb7fab8dfd683aa073e8b99867e66
-=======
-FROM caddy:2.6.4-alpine
->>>>>>> 17a92b6 (Stop using digests, but accept versioned update)
-EXPOSE 3000
->>>>>>> 83631a0 (chore(deps): update caddy docker tag to v2.6.4)
 COPY --from=build /app/Caddyfile /etc/caddy/Caddyfile
 COPY --from=build /app/dist /srv
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,11 +10,16 @@ COPY . .
 RUN npm ci && \
     npm run build
 
+<<<<<<< HEAD
 ### Deploy
 FROM caddy:2.4.6-alpine@sha256:15e576e7d00b1f41a648c5295a03677c24da5fede09131edcb1e6d809c7dc8aa
 ARG PORT
 
 # Copy Caddyfile and static files
+=======
+FROM caddy:2.6.4-alpine@sha256:aacae65cfdcf61777306cf7c131fb968f67bb7fab8dfd683aa073e8b99867e66
+EXPOSE 3000
+>>>>>>> 83631a0 (chore(deps): update caddy docker tag to v2.6.4)
 COPY --from=build /app/Caddyfile /etc/caddy/Caddyfile
 COPY --from=build /app/dist /srv
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -24,4 +24,5 @@ RUN ls /usr/share/caddy
 EXPOSE ${PORT}
 HEALTHCHECK --interval=30s --timeout=3s \
     CMD curl -f http://localhost/:${PORT} || exit 1
-USER app
+# USER app
+RUN cat /etc/passwd

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,6 +11,7 @@ RUN npm ci && \
     npm run build
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 ### Deploy
 FROM caddy:2.4.6-alpine@sha256:15e576e7d00b1f41a648c5295a03677c24da5fede09131edcb1e6d809c7dc8aa
 ARG PORT
@@ -18,6 +19,9 @@ ARG PORT
 # Copy Caddyfile and static files
 =======
 FROM caddy:2.6.4-alpine@sha256:aacae65cfdcf61777306cf7c131fb968f67bb7fab8dfd683aa073e8b99867e66
+=======
+FROM caddy:2.6.4-alpine
+>>>>>>> 17a92b6 (Stop using digests, but accept versioned update)
 EXPOSE 3000
 >>>>>>> 83631a0 (chore(deps): update caddy docker tag to v2.6.4)
 COPY --from=build /app/Caddyfile /etc/caddy/Caddyfile


### PR DESCRIPTION
Fix stuck Renovate branch.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-quickstart-typescript-1066-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-quickstart-typescript-1066-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-quickstart-typescript/actions/workflows/merge-main.yml)